### PR TITLE
スクロール範囲外の item が消えてしまう不具合の修正

### DIFF
--- a/lib/domain/extension/double_extension.dart
+++ b/lib/domain/extension/double_extension.dart
@@ -2,4 +2,6 @@ extension DoubleExtension on double {
   static const int _significantDigit = 5;
   double roundAsSignificant() =>
       double.parse(toStringAsFixed(_significantDigit));
+
+  String toStringOrEmpty() => this > 0 ? toString() : '';
 }

--- a/lib/feature/receipt/presentation/receipt_screen.dart
+++ b/lib/feature/receipt/presentation/receipt_screen.dart
@@ -23,14 +23,17 @@ class ReceiptScreen extends ConsumerWidget {
             child: ListView.separated(
               itemBuilder: (context, index) {
                 final target = state.items[index];
-
-                return ReceiptItem(
-                  item: target,
-                  onChangeName: (value) =>
-                      receiptNotifier.editName(index, value),
-                  onChangePrice: (value) =>
-                      receiptNotifier.editPrice(index, value),
-                  onToggleTax: () => receiptNotifier.toggleTax(index),
+                return ProviderScope(
+                  overrides: [
+                    currentItem.overrideWithValue(target),
+                  ],
+                  child: ReceiptItem(
+                    onChangeName: (value) =>
+                        receiptNotifier.editName(index, value),
+                    onChangePrice: (value) =>
+                        receiptNotifier.editPrice(index, value),
+                    onToggleTax: () => receiptNotifier.toggleTax(index),
+                  ),
                 );
               },
               separatorBuilder: (_, __) => const Divider(),

--- a/lib/feature/receipt/presentation/recept_item.dart
+++ b/lib/feature/receipt/presentation/recept_item.dart
@@ -24,7 +24,8 @@ class ReceiptItem extends HookConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final item = ref.watch(currentItem);
     final nameController = useTextEditingController(text: item.name.value);
-    final priceController = useTextEditingController(text: item.price.value.toStringOrEmpty());
+    final priceController =
+        useTextEditingController(text: item.price.value.toStringOrEmpty());
 
     return ListTile(
       title: TextField(

--- a/lib/feature/receipt/presentation/recept_item.dart
+++ b/lib/feature/receipt/presentation/recept_item.dart
@@ -1,31 +1,38 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
 
+import '../../../domain/extension/double_extension.dart';
 import '../../../domain/value/item.dart';
 
-class ReceiptItem extends ConsumerWidget {
+final currentItem = Provider<Item>((ref) => throw UnimplementedError());
+
+class ReceiptItem extends HookConsumerWidget {
   const ReceiptItem({
     super.key,
-    required this.item,
     required this.onChangeName,
     required this.onChangePrice,
     required this.onToggleTax,
   });
 
-  final Item item;
   final void Function(ItemName) onChangeName;
   final void Function(WithoutTaxPrice) onChangePrice;
   final void Function() onToggleTax;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    final item = ref.watch(currentItem);
+    final nameController = useTextEditingController(text: item.name.value);
+    final priceController = useTextEditingController(text: item.price.value.toStringOrEmpty());
+
     return ListTile(
       title: TextField(
         decoration: const InputDecoration(
           hintText: '商品名(任意)',
         ),
         onChanged: (value) => onChangeName(ItemName(value: value)),
+        controller: nameController,
       ),
       subtitle: Column(
         children: [
@@ -44,6 +51,7 @@ class ReceiptItem extends ConsumerWidget {
                     final input = value.isEmpty ? '0' : value;
                     onChangePrice(WithoutTaxPrice(value: double.parse(input)));
                   },
+                  controller: priceController,
                 ),
               ),
               TextButton(

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -254,6 +254,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_hooks:
+    dependency: "direct main"
+    description:
+      name: flutter_hooks
+      sha256: "9eab8fd7aa752c3c1c0a364f9825851d410eb935243411682f4b1b0a4c569d71"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.20.0"
   flutter_lints:
     dependency: "direct dev"
     description:
@@ -328,6 +336,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.1"
+  hooks_riverpod:
+    dependency: "direct main"
+    description:
+      name: hooks_riverpod
+      sha256: "117edbe7e5cfc02e31a94f97e2acd4581f54bc37fcda9dce1f606f8ac851ba24"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.7"
   hotreloader:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,11 +12,13 @@ dependencies:
   cupertino_icons: ^1.0.2
   flutter:
     sdk: flutter
+  flutter_hooks: ^0.20.0
   flutter_riverpod: ^2.3.6
   flutter_web_plugins:
     sdk: flutter
   freezed_annotation: ^2.4.1
   go_router: ^10.0.0
+  hooks_riverpod: ^2.3.7
   riverpod_annotation: ^2.1.1
 
 dev_dependencies:


### PR DESCRIPTION
画面外に行った widget は破棄されてしまうので、 widget にしかない情報が消えてしまう。  
`Item` をもとに画面の情報を生成するように修正

|before|after|
|:--|:--|
|![before](https://github.com/kktaro/receipt-calculator/assets/26051881/f1ef348a-ce38-409b-be59-884b879c466f)|![after](https://github.com/kktaro/receipt-calculator/assets/26051881/eda3d934-d8ee-40aa-bf9d-8d0c10df25f3)|